### PR TITLE
don't wait 5s to trigger a build

### DIFF
--- a/casc.yml
+++ b/casc.yml
@@ -24,7 +24,7 @@ jenkins:
   primaryView:
     all:
       name: "all"
-  quietPeriod: 5
+  quietPeriod: 0
   scmCheckoutRetryCount: 0
   slaveAgentPort: 50000
   views:


### PR DESCRIPTION
"quiet period" was introduced to support commits sent to SCM in batch, typically when CVS was still a thing. With Git atomic pushes, branch / pull-request based workflow, this doesn't make sense anymore to slow down the CI events by 5s..

see https://jenkins.io/blog/2010/08/11/quiet-period-feature/